### PR TITLE
feat: Implement task reminders via Feishu

### DIFF
--- a/TASK_REMINDER_DOCUMENTATION.md
+++ b/TASK_REMINDER_DOCUMENTATION.md
@@ -1,0 +1,39 @@
+## Task Reminders via Feishu
+
+Stay on top of your deadlines! This application can send reminders for tasks with upcoming due dates directly to your configured Feishu channel.
+
+### User Guide
+
+#### Setting Your Timezone
+
+To ensure reminders are sent at the correct time according to your local timezone, it's important to set your timezone in your profile:
+
+1.  Navigate to **Settings** (typically found in the main application menu or sidebar).
+2.  Within Settings, select the **Profile** tab.
+3.  Find the **Time Zone** dropdown menu.
+4.  Choose your current local timezone from the list.
+5.  Click the **Save Profile Changes** button to apply your selection.
+
+If a timezone is not set in your profile, task reminder times will be based on Coordinated Universal Time (UTC).
+
+#### How Task Reminders Work
+
+-   For any task that has a specific due date and time, the system will aim to send a reminder message.
+-   This reminder will be delivered to the Feishu channel associated with the configured Feishu bot.
+-   Reminders are scheduled to be sent approximately **2 hours before** the task's due date and time.
+-   The due date and time mentioned in the reminder message will be automatically adjusted to reflect the timezone you have set in your user profile. This helps you understand the deadline in your local context.
+-   You will only receive one reminder per task. Reminders will not be sent for tasks that are already marked as 'completed' or 'deleted'.
+
+### Admin & Developer Information
+
+Proper configuration is essential for the Task Reminder feature to operate correctly.
+
+-   **Feishu Webhook Configuration:**
+    The core of the reminder system relies on a Feishu bot. The `FEISHU_WEBHOOK_URL` environment variable **must be configured** in your Supabase project's Edge Function settings (specifically for the `send-reminders` function). This URL is obtained when you create and configure an incoming webhook for a bot in your Feishu instance. Without this URL, reminders cannot be sent.
+
+-   **Scheduling & Processing:**
+    Task reminders are not sent instantaneously when a task is created. Instead, a background job (Supabase Edge Function named `send-reminders`) periodically checks for tasks that are approaching their due date. This job is configured to run at regular intervals (e.g., every 10 minutes, as defined in the `supabase/config.toml` file: `schedule = "*/10 * * * *"`). It then processes eligible tasks and dispatches reminders accordingly.
+
+-   **Environment Variables for the Function:**
+    The `send-reminders` Edge Function also relies on `SUPABASE_URL` and `SUPABASE_ANON_KEY` (or `SUPABASE_SERVICE_ROLE_KEY` if more privileged operations are needed) for interacting with your Supabase database. Ensure these are correctly set in the function's environment.
+```

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,178 @@
+# Testing Guide: Send Reminders Functionality
+
+This guide provides instructions for testing the `send-reminders` Edge Function and related profile timezone settings.
+
+## I. Local Supabase Setup and Environment Variables
+
+1.  **Ensure Local Supabase is Running:**
+    *   Install the Supabase CLI if you haven't already.
+    *   Start your local Supabase instance:
+        ```bash
+        supabase start
+        ```
+    *   Note the local Supabase URL and API keys provided in the output.
+
+2.  **Environment Variables for the Edge Function:**
+    *   Create a `.env` file located at `supabase/functions/.env.local`. This file will be automatically loaded when you serve functions locally.
+    *   Add the following variables to the `.env.local` file, replacing placeholder values with your actual local Supabase details and a mock webhook URL:
+
+        ```env
+        SUPABASE_URL="http://localhost:54321" # Verify this from 'supabase start' output (API URL)
+        SUPABASE_ANON_KEY="your_local_anon_key" # Verify this from 'supabase start' output
+        # SUPABASE_SERVICE_ROLE_KEY="your_local_service_role_key" # Only if your function requires service_role privileges
+        FEISHU_WEBHOOK_URL="your_mock_feishu_webhook_url"
+        ```
+
+    *   **Mock Feishu Webhook:** For `FEISHU_WEBHOOK_URL`, use a service like [Webhook.site](https://webhook.site/) or [Pipedream](https://pipedream.com/). These services provide a URL that will capture and display any HTTP requests sent to them, allowing you to inspect the payload from the `send-reminders` function.
+
+## II. Test Data Setup
+
+You'll need to populate your local database with test users and tasks. You can do this via SQL in the Supabase Studio SQL Editor or by using the application UI if user creation and task creation are implemented.
+
+**Important:** Some `due_date` values for tasks need to be set relative to the current time (`NOW()`) when you are performing the test to ensure they fall into the correct reminder window.
+
+1.  **User Profiles with Timezones:**
+    *   First, ensure corresponding users exist in `auth.users`. You can sign them up via your application or manually insert them if you know how to manage Supabase auth tables.
+    *   Let's assume you have users with IDs: `'auth_user_id_1'`, `'auth_user_id_2'`, `'auth_user_id_3'`. Update these IDs in the `profiles` table inserts.
+
+    ```sql
+    -- Ensure these user IDs match existing entries in auth.users table.
+    -- The 'id' in 'profiles' should be the UUID of the authenticated user.
+    INSERT INTO public.profiles (id, email, full_name, timezone) VALUES
+    ('auth_user_id_1', 'user1@example.com', 'User One NY', 'America/New_York'),
+    ('auth_user_id_2', 'user2@example.com', 'User Two London', 'Europe/London'),
+    ('auth_user_id_3', 'user3@example.com', 'User Three UTC', NULL) -- This user has no timezone set (should default to UTC)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = EXCLUDED.full_name,
+        timezone = EXCLUDED.timezone;
+    ```
+
+2.  **Tasks with Various Due Dates and States:**
+    *   Adjust `user_id` to match the UUIDs of the users created above.
+    *   **Execute these INSERT statements at the time of testing**, as `NOW()` will be evaluated then.
+
+    ```sql
+    -- Task 1: Due in ~1 hour 58 minutes (should trigger reminder). For user_id_1.
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_1', 'Task NYC Due Soon', NOW() + INTERVAL '1 hour 58 minutes', 'todo', 'high', 'This task should trigger a reminder for user in New York.');
+
+    -- Task 2: Due in ~3 hours (should NOT trigger reminder yet). For user_id_2.
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_2', 'Task London Due Later', NOW() + INTERVAL '3 hours', 'todo', 'medium', 'This task is too far in the future for a reminder.');
+
+    -- Task 3: Due in ~1 hour 50 minutes, but reminder_sent_at is already set (should NOT trigger). For user_id_1.
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description, reminder_sent_at) VALUES
+    ('auth_user_id_1', 'Task NYC Already Reminded', NOW() + INTERVAL '1 hour 50 minutes', 'todo', 'high', 'This task should not trigger a new reminder as one was already sent.', NOW() - INTERVAL '10 minutes');
+
+    -- Task 4: Due in ~1 hour 55 minutes, status is 'completed' (should NOT trigger). For user_id_2.
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_2', 'Task London Completed', NOW() + INTERVAL '1 hour 55 minutes', 'completed', 'low', 'Completed tasks should not trigger reminders.');
+
+    -- Task 5: Due in ~1 hour 59 minutes. For user_id_3 (no timezone, should use UTC for reminder).
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_3', 'Task UTC Due Soon No TZ', NOW() + INTERVAL '1 hour 59 minutes', 'todo', 'high', 'This task is for a user with no timezone, should use UTC.');
+
+    -- Task 6: Due in 1 minute (should trigger reminder, tests edge case of being very close to due date but still within reminder window). For user_id_1.
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_1', 'Task NYC Due in 1 Min', NOW() + INTERVAL '1 minute', 'todo', 'critical', 'This task is due very soon.');
+
+    -- Task 7: Due in 2 hours (exact boundary, should trigger). For user_id_2
+    INSERT INTO public.tasks (user_id, title, due_date, status, priority, description) VALUES
+    ('auth_user_id_2', 'Task London Due in 2 Hours Exact', NOW() + INTERVAL '2 hours', 'todo', 'high', 'This task is exactly 2 hours away.');
+    ```
+
+## III. Running the Edge Function Locally
+
+1.  **Serve the function:**
+    Open a terminal in your Supabase project root and run:
+    ```bash
+    supabase functions serve send-reminders --env-file ./supabase/functions/.env.local --no-verify-jwt
+    ```
+    *   `--env-file ./supabase/functions/.env.local` ensures your environment variables are loaded.
+    *   `--no-verify-jwt` is used for ease of testing locally; in production, JWT verification is important.
+    *   The command output will show the URL where the function is being served (e.g., `http://localhost:<port>/send-reminders`). Note this URL.
+
+2.  **Invoke the function:**
+    The `send-reminders` function is designed to be triggered by a cron schedule, but for testing, you can invoke it via an HTTP POST request. Open a new terminal and use `curl` (or a tool like Postman/Insomnia):
+
+    ```bash
+    curl -i -X POST http://localhost:54321/functions/v1/send-reminders \
+      -H "Authorization: Bearer your_local_anon_key" \
+      -H "Content-Type: application/json" \
+      -d '{}'
+    ```
+    *   Replace `http://localhost:54321/functions/v1/send-reminders` with the actual URL shown by the `supabase functions serve` command if it's different (especially the port).
+    *   Replace `your_local_anon_key` with the actual Supabase anon key for your local instance.
+
+## IV. Verification Steps
+
+1.  **Function Logs:**
+    Examine the console output from the `supabase functions serve send-reminders` command. Look for:
+    *   Confirmation messages like:
+        *   `No tasks found needing reminders in the initial fetch window.` (if no tasks currently meet the broad criteria)
+        *   `Feishu reminder sent for task <task_id>`
+        *   `Processed tasks. Reminders sent: X`
+    *   Dates and times in log messages, especially the `formattedDueDate` in the Feishu payload, to ensure they reflect the user's timezone correctly (or UTC for users without a timezone).
+    *   Any error messages:
+        *   `Missing environment variables...`
+        *   `Error fetching tasks:...`
+        *   `Error fetching profile for user ...`
+        *   `Feishu API error for task ...`
+        *   `Error updating task ...`
+
+2.  **Database State:**
+    After invoking the function, query your local `tasks` table in Supabase Studio:
+    ```sql
+    SELECT id, title, due_date, reminder_sent_at, status, user_id
+    FROM public.tasks
+    ORDER BY due_date;
+    ```
+    *   **Verify `reminder_sent_at`:**
+        *   Task 1 ('Task NYC Due Soon') should have `reminder_sent_at` populated with a recent timestamp.
+        *   Task 5 ('Task UTC Due Soon No TZ') should have `reminder_sent_at` populated.
+        *   Task 6 ('Task NYC Due in 1 Min') should have `reminder_sent_at` populated.
+        *   Task 7 ('Task London Due in 2 Hours Exact') should have `reminder_sent_at` populated.
+    *   **Verify `reminder_sent_at` is NOT updated (i.e., remains `NULL`) for:**
+        *   Task 2 ('Task London Due Later')
+        *   Task 3 ('Task NYC Already Reminded') - it was already set, function shouldn't change it.
+        *   Task 4 ('Task London Completed')
+
+3.  **Mock Feishu Endpoint:**
+    Check the dashboard or logs of the service you used for `FEISHU_WEBHOOK_URL` (e.g., Webhook.site):
+    *   You should see incoming POST requests for each task that was expected to trigger a reminder (Task 1, Task 5, Task 6, Task 7).
+    *   Inspect the JSON payload of these requests:
+        *   `msg_type` should be `"text"`.
+        *   `content.text` should be `Reminder: Task "<Task Title>" is due at <Formatted Due Date>.`
+        *   Verify `<Task Title>` is correct.
+        *   Verify `<Formatted Due Date>` is accurate and includes the correct timezone abbreviation (e.g., "Sep 15, 2023, 14:30 (America/New_York)" or "Sep 15, 2023, 18:30 (UTC)" for the user with no timezone).
+
+## V. UI Testing (Manual)
+
+This section focuses on the user profile timezone setting in the application UI.
+
+1.  **Profile Timezone Setting:**
+    *   Log in as a user (e.g., `user1@example.com` / `auth_user_id_1`).
+    *   Navigate to the "Settings" page in the application.
+    *   Find the "Profile" tab and the "Time Zone" selector.
+    *   **Initial State:** Verify if the currently selected timezone in the dropdown matches what's in `public.profiles` for this user (e.g., 'America/New_York').
+    *   **Update Timezone:** Select a new timezone from the dropdown (e.g., 'Asia/Tokyo').
+    *   Click "Save Profile Changes".
+    *   Verify a success toast message appears.
+    *   **Persistence Check 1 (UI):** Refresh the page or navigate away and back to the Settings page. The "Time Zone" selector should show 'Asia/Tokyo'.
+    *   **Persistence Check 2 (DB):** Query the database:
+        ```sql
+        SELECT id, email, timezone FROM public.profiles WHERE id = 'auth_user_id_1';
+        ```
+        Verify the `timezone` column is updated to 'Asia/Tokyo'.
+    *   **Test with Empty/UTC:** Select "UTC" or a "(UTC) Coordinated Universal Time" option if available, save, and verify. If you have a way to clear the timezone (e.g., a "Select your time zone" placeholder that effectively means NULL), test that it correctly sets the DB to `NULL` or 'UTC'.
+
+2.  **(Optional) End-to-End Reminder Flow (Conceptual):**
+    This is a more advanced test combining UI and function invocation.
+    *   Using the UI, set a specific timezone for a test user (e.g., `user1@example.com` to 'America/Los_Angeles').
+    *   Using the UI (if possible) or SQL, create a new task for this user with a `due_date` that is approximately 1 hour and 59 minutes from the current time.
+    *   Manually invoke the `send-reminders` Edge Function locally as described in Section III.
+    *   Check your mock Feishu endpoint. The reminder message should show the task's due time converted to 'America/Los_Angeles' time.
+    *   Check the `tasks` table in the database to ensure `reminder_sent_at` is set for this task.
+
+This concludes the testing guide. Remember to adjust user IDs and dynamic values like `NOW()` + intervals according to your specific test execution times.

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -1,0 +1,76 @@
+import { supabase } from '@/integrations/supabase/client';
+
+// Define Profile Interface
+export interface Profile {
+  id: string;
+  email?: string;
+  full_name?: string;
+  avatar_url?: string;
+  timezone?: string; // Added
+  created_at: Date;
+  updated_at: Date;
+}
+
+// Function to fetch the current user's profile
+export async function getProfile(): Promise<Profile | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    // Or throw new Error('User not authenticated');
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .single();
+
+  if (error) {
+    console.error('Error fetching profile:', error);
+    // Or throw error;
+    return null;
+  }
+  if (!data) return null;
+
+  return {
+     ...data,
+     created_at: new Date(data.created_at),
+     updated_at: new Date(data.updated_at),
+  } as Profile;
+}
+
+// Function to update the current user's profile
+export async function updateProfile(updates: Partial<Omit<Profile, 'id' | 'created_at' | 'updated_at'>>): Promise<Profile | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('User not authenticated for profile update');
+
+  const profileData: any = { ...updates, updated_at: new Date().toISOString() };
+
+  // Remove id, created_at from updates if they somehow got there
+  delete profileData.id;
+  delete profileData.created_at;
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .update(profileData)
+    .eq('id', user.id)
+    .select('*')
+    .single();
+
+  if (error) {
+    console.error('Error updating profile:', error);
+    throw error; // Rethrow to be handled by the caller
+  }
+  if (!data) return null;
+
+  return {
+     ...data,
+     created_at: new Date(data.created_at),
+     updated_at: new Date(data.updated_at),
+  } as Profile;
+}
+
+export const profileService = {
+  getProfile,
+  updateProfile,
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,1 +1,4 @@
 project_id = "tvbeublfxllikjdcmhuy"
+
+[functions.send-reminders]
+schedule = "*/10 * * * *" # Run every 10 minutes

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,5 @@
+// supabase/functions/_shared/cors.ts
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*', // Adjust for production
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -1,0 +1,178 @@
+// supabase/functions/send-reminders/index.ts
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+
+interface Task {
+  id: string;
+  title: string;
+  due_date: string; // ISO string
+  user_id: string;
+  // other fields if needed by the function
+}
+
+interface Profile {
+  timezone?: string;
+  // other fields if needed
+}
+
+// Helper function to format date, ensuring it's a Deno environment
+function formatDateForFeishu(isoDueDate: string, targetTimeZone: string | undefined): string {
+  const date = new Date(isoDueDate);
+  let options: Intl.DateTimeFormatOptions = {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', hour12: false
+  };
+
+  if (targetTimeZone && targetTimeZone !== 'UTC') {
+    try {
+      // Check if timezone is valid before using
+      new Intl.DateTimeFormat('en-US', { timeZone: targetTimeZone }).format(date);
+      options.timeZone = targetTimeZone;
+    } catch (e) {
+      console.warn(`Invalid or unsupported timezone: ${targetTimeZone}. Defaulting to UTC.`);
+      options.timeZone = 'UTC';
+    }
+  } else {
+    options.timeZone = 'UTC';
+  }
+
+  let formattedDate = date.toLocaleString('en-US', options); // Adjust locale as needed
+  if (options.timeZone) {
+     formattedDate += ` (${options.timeZone})`;
+  }
+  return formattedDate;
+}
+
+
+serve(async (req: Request) => {
+  // Handle OPTIONS request for CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+    const feishuWebhookUrl = Deno.env.get('FEISHU_WEBHOOK_URL');
+
+    if (!supabaseUrl || !supabaseAnonKey || !feishuWebhookUrl) {
+      console.error('Missing environment variables: SUPABASE_URL, SUPABASE_ANON_KEY, or FEISHU_WEBHOOK_URL');
+      return new Response(JSON.stringify({ error: 'Missing configuration' }), {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase: SupabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+
+    const now = new Date();
+    // Fetch tasks due between now and ~2 hours 5 mins from now.
+    // The inner loop will further refine if it's exactly 2 hours before due.
+    const reminderWindowEnd = new Date(now.getTime() + 2 * 60 * 60 * 1000 + 5 * 60 * 1000);   // 2 hours 5 minutes from now
+
+    // 1. Fetch tasks that are due within the next ~2 hours, not completed, and no reminder sent
+    const { data: tasks, error: tasksError } = await supabase
+      .from('tasks')
+      .select('id, title, due_date, user_id')
+      .is('reminder_sent_at', null) // Reminder not yet sent
+      .neq('status', 'completed')   // Not completed
+      .neq('status', 'deleted')     // Not deleted
+      .lte('due_date', reminderWindowEnd.toISOString()) // Due date is within the reminder window end
+      .gte('due_date', now.toISOString()); // Due date is in the future from now (prevents old tasks)
+
+
+    if (tasksError) {
+      console.error('Error fetching tasks:', tasksError);
+      throw tasksError;
+    }
+
+    if (!tasks || tasks.length === 0) {
+      console.log('No tasks found needing reminders in the initial fetch window.');
+      return new Response(JSON.stringify({ message: 'No tasks to remind in the window.' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    let remindersSentCount = 0;
+
+    for (const task of tasks as Task[]) {
+      const dueDate = new Date(task.due_date);
+      // Calculate the exact time when a reminder should be sent (2 hours before due date)
+      const reminderTime = new Date(dueDate.getTime() - 2 * 60 * 60 * 1000);
+
+      // Check if it's time to send the reminder (current time is past the calculated reminder time)
+      // And also ensure we are not sending it too late (e.g. if due_date itself is very close to now or in past)
+      if (now >= reminderTime && now < dueDate) {
+        // Fetch user's profile for timezone
+        let userTimeZone: string | undefined = 'UTC'; // Default to UTC
+        const { data: profile, error: profileError } = await supabase
+          .from('profiles')
+          .select('timezone')
+          .eq('id', task.user_id)
+          .single();
+
+        if (profileError) {
+          console.warn(`Error fetching profile for user ${task.user_id}:`, profileError.message);
+          // Proceed with UTC if profile fetch fails
+        } else if (profile && (profile as Profile).timezone) {
+          userTimeZone = (profile as Profile).timezone;
+        }
+
+        const formattedDueDate = formatDateForFeishu(task.due_date, userTimeZone);
+        const messageBody = {
+          msg_type: 'text',
+          content: {
+            text: `Reminder: Task "${task.title}" is due at ${formattedDueDate}.`,
+          },
+        };
+
+        // Send to Feishu
+        try {
+          const feishuResponse = await fetch(feishuWebhookUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(messageBody),
+          });
+
+          if (!feishuResponse.ok) {
+            const errorBody = await feishuResponse.text();
+            console.error(`Feishu API error for task ${task.id}: ${feishuResponse.status} ${feishuResponse.statusText}`, errorBody);
+            // Continue to next task, don't mark as reminder sent
+            continue;
+          }
+
+          console.log(`Feishu reminder sent for task ${task.id}`);
+
+          // Update task to mark reminder as sent
+          const { error: updateError } = await supabase
+            .from('tasks')
+            .update({ reminder_sent_at: new Date().toISOString() })
+            .eq('id', task.id);
+
+          if (updateError) {
+            console.error(`Error updating task ${task.id} after sending reminder:`, updateError);
+            // If update fails, the reminder might be sent again. This is a trade-off.
+          } else {
+            remindersSentCount++;
+          }
+
+        } catch (feishuError) {
+          console.error(`Failed to send Feishu message for task ${task.id}:`, feishuError);
+          // Continue to next task
+        }
+      }
+    }
+
+    return new Response(JSON.stringify({ message: `Processed tasks. Reminders sent: ${remindersSentCount}` }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+
+  } catch (error) {
+    console.error('Unhandled error in send-reminders function:', error);
+    return new Response(JSON.stringify({ error: error.message || 'Unknown error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20250610072031_add_timezone_and_reminder_tracking.sql
+++ b/supabase/migrations/20250610072031_add_timezone_and_reminder_tracking.sql
@@ -1,0 +1,10 @@
+-- Add timezone column to profiles table
+ALTER TABLE public.profiles
+ADD COLUMN timezone TEXT;
+
+-- Add reminder_sent_at column to tasks table
+ALTER TABLE public.tasks
+ADD COLUMN reminder_sent_at TIMESTAMP WITH TIME ZONE;
+
+-- Optionally, update policies if needed, though for these columns, it's unlikely.
+-- Add comments to explain the changes.


### PR DESCRIPTION
This feature introduces a task reminder system that sends notifications to a configured Feishu bot 2 hours before a task's due date.

Key changes include:

1.  **Database Schema:**
    *   Added `timezone` column to `public.profiles` table to allow you
      to set your preferred timezone.
    *   Added `reminder_sent_at` column to `public.tasks` table to track
      when a reminder has been dispatched.
    *   New migration: `20250610072031_add_timezone_and_reminder_tracking.sql`

2.  **User Profile Management:**
    *   Created `src/services/profileService.ts` with functions to get
      and update user profiles, including their timezone.
    *   Modified `src/components/features/SettingsView.tsx` to add a
      "Profile" tab where you can select and save your timezone.

3.  **Reminder Logic (Supabase Edge Function):**
    *   Created a new Supabase Edge Function `send-reminders`
      (`supabase/functions/send-reminders/index.ts`).
    *   This function queries tasks due within the reminder window,
      fetches your timezone, formats the due date accordingly,
      and sends a message to the Feishu webhook URL.
    *   It updates `tasks.reminder_sent_at` after sending.

4.  **Scheduling:**
    *   Configured the `send-reminders` Edge Function to run every 10
      minutes using a cron schedule in `supabase/config.toml`.

5.  **Testing & Documentation:**
    *   Created `TESTING_GUIDE.md` with instructions for testing the
      feature locally.
    *   Created `TASK_REMINDER_DOCUMENTATION.md` explaining how to use
      the feature and necessary configurations (e.g., `FEISHU_WEBHOOK_URL`).

This implementation ensures that reminders are timely and respect user-defined timezones for accurate notification delivery.