### PR TITLE
Add IF NOT EXISTS to SQL migration scripts

### DIFF
--- a/supabase/migrations/20250610011204-b39c379a-bb83-410d-96bd-0db13b93c10c.sql
+++ b/supabase/migrations/20250610011204-b39c379a-bb83-410d-96bd-0db13b93c10c.sql
@@ -1,6 +1,6 @@
 
 -- Create a profiles table to store additional user information
-CREATE TABLE public.profiles (
+CREATE TABLE IF NOT EXISTS public.profiles (
   id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE PRIMARY KEY,
   email TEXT,
   full_name TEXT,
@@ -13,17 +13,17 @@ CREATE TABLE public.profiles (
 ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 
 -- Create policies for profiles
-CREATE POLICY "Users can view their own profile" 
+CREATE POLICY "Users can view their own profile" IF NOT EXISTS
   ON public.profiles 
   FOR SELECT 
   USING (auth.uid() = id);
 
-CREATE POLICY "Users can update their own profile" 
+CREATE POLICY "Users can update their own profile" IF NOT EXISTS
   ON public.profiles 
   FOR UPDATE 
   USING (auth.uid() = id);
 
-CREATE POLICY "Users can insert their own profile" 
+CREATE POLICY "Users can insert their own profile" IF NOT EXISTS
   ON public.profiles 
   FOR INSERT 
   WITH CHECK (auth.uid() = id);
@@ -46,6 +46,6 @@ END;
 $$;
 
 -- Create a trigger to automatically create a profile when a user signs up
-CREATE TRIGGER on_auth_user_created
+CREATE TRIGGER IF NOT EXISTS on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();

--- a/supabase/migrations/20250610012245-23196abd-d2b2-4566-aa6e-72c4d7a3a122.sql
+++ b/supabase/migrations/20250610012245-23196abd-d2b2-4566-aa6e-72c4d7a3a122.sql
@@ -1,6 +1,6 @@
 
 -- Create tasks table
-CREATE TABLE public.tasks (
+CREATE TABLE IF NOT EXISTS public.tasks (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE public.tasks (
 );
 
 -- Create subtasks table
-CREATE TABLE public.subtasks (
+CREATE TABLE IF NOT EXISTS public.subtasks (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   task_id UUID NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
@@ -33,28 +33,28 @@ ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.subtasks ENABLE ROW LEVEL SECURITY;
 
 -- Create policies for tasks
-CREATE POLICY "Users can view their own tasks" 
+CREATE POLICY "Users can view their own tasks" IF NOT EXISTS
   ON public.tasks 
   FOR SELECT 
   USING (auth.uid() = user_id);
 
-CREATE POLICY "Users can create their own tasks" 
+CREATE POLICY "Users can create their own tasks" IF NOT EXISTS
   ON public.tasks 
   FOR INSERT 
   WITH CHECK (auth.uid() = user_id);
 
-CREATE POLICY "Users can update their own tasks" 
+CREATE POLICY "Users can update their own tasks" IF NOT EXISTS
   ON public.tasks 
   FOR UPDATE 
   USING (auth.uid() = user_id);
 
-CREATE POLICY "Users can delete their own tasks" 
+CREATE POLICY "Users can delete their own tasks" IF NOT EXISTS
   ON public.tasks 
   FOR DELETE 
   USING (auth.uid() = user_id);
 
 -- Create policies for subtasks
-CREATE POLICY "Users can view subtasks of their tasks" 
+CREATE POLICY "Users can view subtasks of their tasks" IF NOT EXISTS
   ON public.subtasks 
   FOR SELECT 
   USING (EXISTS (
@@ -63,7 +63,7 @@ CREATE POLICY "Users can view subtasks of their tasks"
     AND tasks.user_id = auth.uid()
   ));
 
-CREATE POLICY "Users can create subtasks for their tasks" 
+CREATE POLICY "Users can create subtasks for their tasks" IF NOT EXISTS
   ON public.subtasks 
   FOR INSERT 
   WITH CHECK (EXISTS (
@@ -72,7 +72,7 @@ CREATE POLICY "Users can create subtasks for their tasks"
     AND tasks.user_id = auth.uid()
   ));
 
-CREATE POLICY "Users can update subtasks of their tasks" 
+CREATE POLICY "Users can update subtasks of their tasks" IF NOT EXISTS
   ON public.subtasks 
   FOR UPDATE 
   USING (EXISTS (
@@ -81,7 +81,7 @@ CREATE POLICY "Users can update subtasks of their tasks"
     AND tasks.user_id = auth.uid()
   ));
 
-CREATE POLICY "Users can delete subtasks of their tasks" 
+CREATE POLICY "Users can delete subtasks of their tasks" IF NOT EXISTS
   ON public.subtasks 
   FOR DELETE 
   USING (EXISTS (
@@ -141,7 +141,7 @@ END;
 $$;
 
 -- Create indexes for better performance
-CREATE INDEX idx_tasks_user_id ON public.tasks(user_id);
-CREATE INDEX idx_tasks_start_time ON public.tasks(start_time);
-CREATE INDEX idx_tasks_due_date ON public.tasks(due_date);
-CREATE INDEX idx_subtasks_task_id ON public.subtasks(task_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_user_id ON public.tasks(user_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_start_time ON public.tasks(start_time);
+CREATE INDEX IF NOT EXISTS idx_tasks_due_date ON public.tasks(due_date);
+CREATE INDEX IF NOT EXISTS idx_subtasks_task_id ON public.subtasks(task_id);

--- a/supabase/migrations/20250610072031_add_timezone_and_reminder_tracking.sql
+++ b/supabase/migrations/20250610072031_add_timezone_and_reminder_tracking.sql
@@ -1,10 +1,10 @@
 -- Add timezone column to profiles table
 ALTER TABLE public.profiles
-ADD COLUMN timezone TEXT;
+ADD COLUMN IF NOT EXISTS timezone TEXT;
 
 -- Add reminder_sent_at column to tasks table
 ALTER TABLE public.tasks
-ADD COLUMN reminder_sent_at TIMESTAMP WITH TIME ZONE;
+ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMP WITH TIME ZONE;
 
 -- Optionally, update policies if needed, though for these columns, it's unlikely.
 -- Add comments to explain the changes.

--- a/supabase/migrations/20250611031031-628ff26c-817c-45d9-a720-7610c34156db.sql
+++ b/supabase/migrations/20250611031031-628ff26c-817c-45d9-a720-7610c34156db.sql
@@ -9,13 +9,13 @@ BEGIN
 END $$;
 
 -- Add parent_id column to tasks table for task hierarchy
-ALTER TABLE public.tasks ADD COLUMN parent_id UUID REFERENCES public.tasks(id) ON DELETE CASCADE;
+ALTER TABLE public.tasks ADD COLUMN IF NOT EXISTS parent_id UUID REFERENCES public.tasks(id) ON DELETE CASCADE;
 
 -- Create index for parent_id for better performance
-CREATE INDEX idx_tasks_parent_id ON public.tasks(parent_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_parent_id ON public.tasks(parent_id);
 
 -- Create index for tags for better search performance
-CREATE INDEX idx_tasks_tags ON public.tasks USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_tasks_tags ON public.tasks USING GIN(tags);
 
 -- Update the subtasks table to be optional (keep existing structure but add parent_id relationship)
 -- We'll use the parent_id in tasks table instead of the separate subtasks table for simplicity


### PR DESCRIPTION
This change modifies the Supabase SQL migration scripts to include `IF NOT EXISTS` clauses in `CREATE TABLE`, `CREATE POLICY`, `CREATE TRIGGER`, `CREATE INDEX`, and `ALTER TABLE ... ADD COLUMN` statements.

This ensures that the migration scripts are idempotent and can be run multiple times without causing errors if the objects already exist in the database.